### PR TITLE
Answers and questions ui cleanup and bug fixes

### DIFF
--- a/app/assets/javascripts/answers.js
+++ b/app/assets/javascripts/answers.js
@@ -1,121 +1,52 @@
-//hide and show answers
-$(document).ready(function(e){
-
-// Defines function that gives the user feedback once they state whether or not they have gotten the question right. 
-// This function also stores the user response in the development_analytics.log using an ajax call. 
-  function provide_feedback(is_correct, notice_text, q_id, color_class) {
-    
-      $.ajax({
-        url: window.location.pathname + "/" + q_id + "/feedback",
-        type: "POST",
-        data: { correct: is_correct }
-      })
-      .done(function( data ) {
-        $('#alert_text_container').addClass(color_class);
-        $('#alert_text').text(notice_text);
-        $('.alert').slideDown();
-    });
-       $('#alert_text_container').removeClass("alert-danger").addClass("alert-success");
-  };
-
-  //provide_feedback function for the STANDALONE page
-  function single_provide_feedback(is_correct, notice_text, color_class) {
-    
-      $.ajax({
-        url: window.location.pathname + "/feedback",
-        type: "POST",
-        data: { correct: is_correct }
-      })
-      .done(function( data ) {
-        $('#single-alert-text-container').addClass(color_class);
-        $('#single_alert_text').text(notice_text);
-        $('.alert').slideDown();
-    });
-  };
- 
-//JAVASCRIPT FOR THE MODULE
-// Defines function that disables/enables submit button depending on if there is text in the answer box
-function enableSubmitAnswer() {
-  if ($('#answer_text').val()) {
-    $('#submit_answer').attr('disabled', false);
-  } else {
-    $('#submit_answer').attr('disabled', true); 
-  }
+function sendFeedback(feedbackUrl, isCorrect) {
+  $.ajax({
+    url: feedbackUrl,
+    type: "POST",
+    data: { correct: isCorrect }
+  });
 }
 
-// Function is called as soon as page is loaded so that submit button can be disabled initially 
-enableSubmitAnswer(); 
+function handleUserFeedback(feedbackActive, feedbackString, feedbackQid) {
+  if (feedbackActive) { sendFeedback('/questions/' + feedbackQid + '/feedback', feedbackString);}
+  if (feedbackString == 'yes') {
+    $('.feedback-alert').removeClass('alert-danger').addClass('alert-success');
+    $('.feedback-alert-text').text('Great! Congrats! Try another question.');
+  } else {
+    $('.feedback-alert').removeClass('alert-success').addClass('alert-danger');
+    $('.feedback-alert-text').text("No worries. You'll get it next time. Onwards!");
+  }
+  $('.feedback-alert').slideDown();
+  $('.response').hide("slow");
+}
 
-// runs each time the user presses a key in the #answer_text form field
-$('#answer_text').keyup(enableSubmitAnswer); 
+// disables/enables submit button depending on if there is text in the answer box
+function validateAnswer() {
+  $('.submit-answer').attr('disabled', !$('.answer-text').val().trim());
+}
 
-// When a user submits an answer. The real answer and response form fade in. 
-$("#submit_answer").click(function(ev){
+function initUserFeedback() {
+  $('.feedback-button').click(function(ev) {
+    ev.preventDefault(); // prevents bootstrap from automatically adding a hidden attribute
+    var $button = $(ev.target).closest('.feedback-button');
+    var feedbackActive = $button.data('feedback-active');
+    var feedbackString = $button.data('feedback-string');
+    var feedbackQid = $button.data('feedback-qid');
+    handleUserFeedback(feedbackActive, feedbackString, feedbackQid);
+  });
+}
+
+function initAnswerButton() {
+  // Function is called as soon as page is loaded so that submit button can be disabled initially
+  validateAnswer();
+
+  // validates input each time the user presses a key in the #answer_text form field
+  $('.answer-text').keyup(validateAnswer);
+
+  // When a user submits an answer, the real answer and response form fade in.
+  $(".submit-answer").click(function (ev) {
     // prevents bootstrap from automatically adding a hidden attribute; we are explicitly hiding and showing using jquery instead
-     ev.preventDefault(); 
-     $("#answers").fadeIn();
-     $("#submit_answer").hide("slow");
-     $("#response").fadeIn();
-});
-
-$('#respond-yes').click(function(ev) {
-  $('#respond-yes').fadeIn();
-  ev.preventDefault(); // prevents bootstrap from automatically adding a hidden attribute
-  provide_feedback("yes", "Great! Congrats! Try another question.", $('#respond-yes').data('q_id'),"alert-success");
-  $('#response').hide("slow");
-});
-
-$('#respond-no').click(function(ev) {
-  $('#respond-no').fadeIn();
-  ev.preventDefault(); // prevents bootstrap from automatically adding a hidden attribute
-  provide_feedback("no", "No worries. You'll get it next time. Onwards!", $('#respond-no').data('q_id'),"alert-danger");
-  $('#response').hide("slow");
-});
-
-//JAVASCRIPT FOR THE STANDALONE PAGE
- //Hiding the answers and response div for standalone question page
- $("#single-answers").hide();
- $("#single-response").hide();
-
-// Defines function that disables/enables submit button depending on if there is text in the answer box
-function single_enableSubmitAnswer() {
-  if ($('#single-answer-text').val()) {
-    $('#single-submit-answer').attr('disabled', false);
-  } else {
-    $('#single-submit-answer').attr('disabled', true); 
-  }
+    ev.preventDefault();
+    $(".answers, .response").fadeIn();
+    $(".submit-answer").hide("slow");
+  });
 }
-
-// Function is called as soon as page is loaded so that submit button can be disabled initially 
-single_enableSubmitAnswer(); 
-
-// runs each time the user presses a key in the #answer_text form field
-$('#single-answer-text').keyup(single_enableSubmitAnswer); 
-
-// When a user submits an answer. The real answer and response form fade in. 
-  $("#single-submit-answer").click(function(ev){
-      // prevents bootstrap from automatically adding a hidden attribute; we are explicitly hiding and showing using jquery instead
-       ev.preventDefault(); 
-       $("#single-answers").fadeIn();
-       $("#single-submit-answer").hide("slow");
-       $("#single-response").fadeIn();
-
-  });
-
-  $('#single-respond-yes').click(function(ev) {
-    $('#single-respond-yes').fadeIn();
-    ev.preventDefault(); // prevents bootstrap from automatically adding a hidden attribute
-    single_provide_feedback("yes", "Great! Congrats! Try another question.", "alert-success");
-    $('#single-response').hide("slow");
-  });
-
-  $('#single-respond-no').click(function(ev) {
-    $('#single-respond-no').fadeIn();
-    ev.preventDefault(); // prevents bootstrap from automatically adding a hidden attribute
-    single_provide_feedback("no", "No worries. You'll get it next time. Onwards!", "alert-danger");
-    $('#single-response').hide("slow");
-  });
-
-});
-
-

--- a/app/assets/javascripts/answers.js
+++ b/app/assets/javascripts/answers.js
@@ -11,9 +11,6 @@ $(document).ready(function(e){
         data: { correct: is_correct }
       })
       .done(function( data ) {
-        if ( console && console.log ) {
-          console.log( "Sample of data:", data.slice( 0, 100 ) );
-        }
         $('#alert_text_container').addClass(color_class);
         $('#alert_text').text(notice_text);
         $('.alert').slideDown();
@@ -30,9 +27,6 @@ $(document).ready(function(e){
         data: { correct: is_correct }
       })
       .done(function( data ) {
-        if ( console && console.log ) {
-          console.log( "Sample of data:", data.slice( 0, 100 ) );
-        }
         $('#single-alert-text-container').addClass(color_class);
         $('#single_alert_text').text(notice_text);
         $('.alert').slideDown();

--- a/app/assets/javascripts/questions.js
+++ b/app/assets/javascripts/questions.js
@@ -1,118 +1,91 @@
-$(document).ready(function(q){
-
-    $("#mine-radio").click(function(){
-      $('.my-question').removeClass('hidden');
-      $('.other-question').addClass('hidden');
-    });
-
-    $('#other-radio').click(function(){
-      $('.my-question').addClass('hidden');
-      $('.other-question').removeClass('hidden');
-    });
-  
-// Defines function that disables/enables submit button depending on if there is text in the answer box
-function enableSubmitAnswer() {
-  if ($('#answer_text').val()) {
-    $('#submit_answer').attr('disabled', false);
-  } else {
-    $('#submit_answer').attr('disabled', true); 
-  }
+function validateEditQuestionInput() {
+  // disables/enables submit button depending on if there is text in the question and answer boxes
+  var isValid = $('#question_text').val().trim() && $('#question_answers_attributes_0_text').val().trim();
+  $('.submit-question').attr('disabled', !isValid);
 }
 
+function initQuestionFilter() {
+  $("#mine-radio").click(function(){
+    $('.my-question').removeClass('hidden');
+    $('.other-question').addClass('hidden');
+  });
 
-// Creates the javscript for the Question modal that allows it to be populated with the data recieved upon clicking the modal link
+  $('#other-radio').click(function(){
+    $('.my-question').addClass('hidden');
+    $('.other-question').removeClass('hidden');
+  });
+}
 
-$('#question_display_Modal').on('show.bs.modal', function (event) {
-  
-  // Creates the initial view of the modal. The submit answer is shown as well as an empty text box. 
-  // The answer is initally hidden and so is the response + alert forms. 
-  $("#submit_answer").show();
-  $('#answer_text').val("");
-    // initially hides the answers and response form in the modal 
-  $("#response, #answers, #alert_text_container").hide();
-  enableSubmitAnswer();  
+function initQuestionDisplayModal($modal, $question_link) {
+  // Creates the initial view of the modal.
 
-  var question_link = $(event.relatedTarget); // element that triggered the modal. question_link is populated with the data from the click 
+  // The submit answer button is shown as well as an empty text input box.
+  $('.submit-answer').show();
 
-  // Creates variables with data that we will later use to populate certain parts of the modal 
-  var text_question = question_link.data('question');
-  var first_answer = question_link.data('answer');  
-  
+  // The answer is initially hidden and so is the response + alert divs.
+  $('.answer-text').val('');
+  $('.response, .answers, .feedback-alert').hide();
+
+  initAnswerButton();
+  initUserFeedback();
+
   // Setting up the response buttons to have the correct q_id to send to the analytics.log and to also trigger the right feedback form
-  $('#respond-yes').data('q_id', question_link.data('q_id')); 
-  $('#respond-no').data('q_id', question_link.data('q_id'));  
+  $('#respond-yes, #respond-no').data('feedback-qid', $question_link.data('qid'));
 
- 
-  // Searches the modal and populates the indicated classes with the data recieved when the modal was clicked
-  var modal = $(this);
-  modal.find('.modal-title').text(text_question);
-  modal.find('.first-answer').text(first_answer);
-})
-
-// Creates the javscript for the Social modal that allows it to be populated with the data recieved upon clicking the modal link
-$('#social_display_Modal').on('show.bs.modal', function (event) {
-  var social_link = $(event.relatedTarget); // element that triggered the modal. social_link is populated with the data from the click 
-  
-  // Creates variables with data that we will later use to populate certain parts of the modal 
-  var title = social_link.data('website');
-  var text_question = social_link.data('question');
-  var url_link = social_link.data('url');
-  var hyperlink = social_link.data('hyperlink');
-  var hyperlinktext = social_link.data('hyperlinktext');
-
-  // Searches the modal and populates the indicated classes with the data recieved when the modal was clicked
-  var modal = $(this);
-  modal.find('.modal-title').text(title); // sets the title 
-  modal.find('.modal-body-social input').val(text_question + " ➡" + "Follow the link to find out the answer: " + url_link); // creates the text that includes the question and url for user to copy to clipboard
-  modal.find('.hyperlink').attr("href", hyperlink); // updates the href to the appropriate social platform the second attribute allows the social site to be opened on a new page 
-  modal.find('.hyperlink').text(hyperlinktext); // creates the text that the hyperlink will show up as 
-})
-
-// Defines function that disables/enables submit button depending on if there is text in the question and answer boxes
-function enableSubmitQuestion() {
-  if ($('#question_text').val() && $('#question_answers_attributes_0_text').val()) {
-    $('#submit_question').attr('disabled', false);
-  } else {
-    $('#submit_question').attr('disabled', true);
-  }
+  // Populates the modal with the data received when the modal was clicked
+  $modal.find('.modal-title').text($question_link.data('question'));
+  $modal.find('.first-answer').text($question_link.data('answer'));
 }
 
-// enables/disables the submit question button on page load
-enableSubmitQuestion(); 
+function initSocialModal($modal, $social_link) {
+  var title = $social_link.data('website');
+  var text_question = $social_link.data('question');
+  var url_link = $social_link.data('url');
+  var hyperlink = $social_link.data('hyperlink');
+  var hyperlinktext = $social_link.data('hyperlinktext');
 
-// runs each time the user presses a key in the #answer_text form field
-$('#question_text, #question_answers_attributes_0_text').keyup(enableSubmitQuestion);
+  // Populates the modal with the data received when the modal was clicked
+  $modal.find('.modal-title').text(title); // sets the title
+  $modal.find('.modal-body-social input').val(text_question + " ➡" + "Follow the link to find out the answer: " + url_link); // creates the text that includes the question and url for user to copy to clipboard
+  $modal.find('.hyperlink').attr("href", hyperlink); // updates the href to the appropriate social platform the second attribute allows the social site to be opened on a new page
+  $modal.find('.hyperlink').text(hyperlinktext); // creates the text that the hyperlink will show up as
+}
 
-$('#question-groups').on('change', function(event) {
+function initQuestionGroups() {
+  $('#question-groups').on('change', function(event) {
     var val = $(this).val();
     if (val == 'new') {
-        $('#modal-new-question-group').modal();
+      $('#modal-new-question-group').modal();
     } else {
-        window.open('questions?question_group_id=' + val, '_self');
+      window.open('questions?question_group_id=' + val, '_self');
     }
-});
+  });
 
-$('#modal-new-question-group').on('show.bs.modal', function (event) {
+  $('#modal-new-question-group').on('show.bs.modal', function (event) {
     var $modal = $(this);
     var currentQuestionGroupName = $('#edit-question-group').text().trim();
     $modal.find('input[name="name"]').val('');
     $modal.find('input[name="parent"]').val(currentQuestionGroupName);
-});
-
-$('#modal-new-question-group').on('hide.bs.modal', function (event) {
+  }).on('hide.bs.modal', function (event) {
     $('#question-groups').val('');  // reset the question group dropdown
-});
+  });
 
-$('#edit-question-group').on('click', function (event) {
+  $('#edit-question-group').on('click', function (event) {
     var $modal = $('#modal-edit-question-group');
     var $link = $(event.target);
     $modal.find('input[name="name"]').val($link.text().trim());
     $('#delete_confirmation_form_container').hide();
-});
+  });
 
-$('#edit-question-group-delete').on('click', function (event) {
+  $('#edit-question-group-delete').on('click', function (event) {
     $('#delete_confirmation_form_container').show();
-});
+  });
+}
 
-});
+function initEditQuestion() {
+  // initialize the submit button
+  validateEditQuestionInput();
 
+  // check for valid input each time the user presses a key in the #question_text form field
+  $('#question_text, #question_answers_attributes_0_text').keyup(validateEditQuestionInput);
+}

--- a/app/assets/stylesheets/answers.css.scss
+++ b/app/assets/stylesheets/answers.css.scss
@@ -2,7 +2,7 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
-#single-response, #response {
+.response {
   .yes {
     text-align: right;
   }
@@ -22,8 +22,8 @@
     color: white;
   }
 }
-#single-answers, #answers {
-  .correct_div {
+.answers {
+  .correct-container {
     width: 95%;
     margin-right: auto;
     margin-left: auto;
@@ -39,7 +39,7 @@
   
 }
 
-#single-respond-yes, #single-respond-no {
+.feedback-button {
   cursor: pointer;
 }
 

--- a/app/views/questions/_modal_question.erb
+++ b/app/views/questions/_modal_question.erb
@@ -20,10 +20,9 @@
           <div style="display:none">
             <input name="utf8" type="hidden" value="✓" />
           </div>
-          <textarea class="form-control" id="answer_text" name="answer[text]" placeholder="Type your answer here"></textarea>
+          <textarea class="form-control answer-text" name="answer[text]" placeholder="Type your answer here"></textarea>
           <div class="center btn-div">
-            <input class="btn btn-theme btn-lg"
-                   id="submit_answer"
+            <input class="btn btn-theme btn-lg submit-answer"
                    name="commit"
                    type="submit"
                    value="Submit answer" />
@@ -31,7 +30,7 @@
         </form>
 
         <!-- Displays the correct answer to the question once the user submits their answer -->
-        <div id="answers" class="prettyform">
+        <div class="prettyform answers">
           <div class="container">
             <div class="box center" style="display: block;">
               <h3>Answer:</h3>
@@ -41,23 +40,31 @@
         </div>
 
         <!-- Allows the user to note whether or not they got the question right. Creates two buttons, of which the user presses one (yes/no).-->
-        <div id="response">
+        <div class="response">
           <br>
           <h4 class="center"><b>Did you know the answer?</b></h4>
           <div class="row">
             <div class="col-xs-6 yes">
-              <a id="respond-yes" class="btn-flat btn-success"><i class="fa fa-check"></i></a>
+              <a id="respond-yes" class="btn-flat btn-success feedback-button"
+                 data-feedback-active="<%= !!current_user %>"
+                 data-feedback-string="yes">
+                <i class="fa fa-check"></i>
+              </a>
             </div>
-            <div class="col-xs-6">
-              <a id="respond-no" class="btn-flat btn-pink"><i class="fa fa-times"></i></a>
+            <div class="col-xs-6 no">
+              <a id="respond-no" class="btn-flat btn-pink feedback-button"
+                data-feedback-active="<%= !!current_user %>"
+                data-feedback-string="no">
+                <i class="fa fa-times"></i>
+              </a>
             </div>
           </div>
         </div>
         <br>
 
         <!-- Alert box appears after the user answers whether or not they got the question right  -->
-        <div id="alert_text_container" class="alert center" style>
-          <div id="alert_text"> </div>
+        <div class="alert feedback-alert center">
+          <div class="feedback-alert-text"> </div>
           &nbsp;
           <a class="close-alert grow"><i class="fa fa-times-circle"></i></a>
         </div>
@@ -65,3 +72,13 @@
     </div>
   </div>
 </div>
+
+<script>
+  $(document).ready(function(){
+    // Creates the javascript for the Question modal that allows it to be populated with the data received upon clicking the modal link
+    $('#question_display_Modal').on('show.bs.modal', function (event) {
+      var $question_link = $(event.relatedTarget); // element that triggered the modal. $question_link is populated with the data from the click
+      initQuestionDisplayModal($(this), $question_link);
+    })
+  });
+</script>

--- a/app/views/questions/_modal_social.html.erb
+++ b/app/views/questions/_modal_social.html.erb
@@ -27,3 +27,14 @@
     </div>
   </div>
 </div>
+
+<script>
+  $(document).ready(function(){
+    // Creates the javascript for the Social modal that allows it to be populated with the data received upon clicking the modal link
+    $('#social_display_Modal').on('show.bs.modal', function (event) {
+      var $modal = $(this);
+      var $social_link = $(event.relatedTarget); // element that triggered the modal. $social_link is populated with the data from the click
+      initSocialModal($modal, $social_link);
+    })
+  });
+</script>

--- a/app/views/questions/edit.html.erb
+++ b/app/views/questions/edit.html.erb
@@ -16,7 +16,7 @@
                 <%= a.hidden_field :question_id %>
               <% end %>
               <div class="center btn-div">
-                <%= f.submit "Save question", class: 'btn btn-theme btn-lg', id: 'save_question' %>
+                <%= f.submit "Save question", class: 'btn btn-theme btn-lg submit-question' %>
                 <%= link_to "Cancel", questions_path(question_group_id: @current_question_group_id), class: "btn btn-flat btn-lg" %>
               </div>
             <%end%>
@@ -28,3 +28,9 @@
     </div>
   </div>
 </div>
+
+<script>
+  $(document).ready(function(){
+    initEditQuestion();
+  });
+</script>

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -108,3 +108,10 @@
   <%= render "modal_edit_question_group" %>
   <%= render "modal_new_question_group" %>
 <% end %>
+
+<script>
+  $(document).ready(function(){
+    initQuestionGroups();
+    initQuestionFilter();
+  });
+</script>

--- a/app/views/questions/new.html.erb
+++ b/app/views/questions/new.html.erb
@@ -13,7 +13,7 @@
                 <%= a.text_area :text, placeholder: 'Answer',  class: 'form-control' %>
               <% end %>
               <div class="center btn-div">
-                <%= f.submit "Submit question", class: 'btn btn-theme btn-lg', id: 'submit_question' %>
+                <%= f.submit "Submit question", class: 'btn btn-theme btn-lg submit-question' %>
               </div>
             <%end%>
         </div>
@@ -24,3 +24,9 @@
     </div>
   </div>
 </div>
+
+<script>
+  $(document).ready(function(){
+    initEditQuestion();
+  });
+</script>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -1,5 +1,5 @@
-<div id="single-alert-text-container" class="alert center" style="display: none;">
-  <div id= "single_alert_text"> </div>
+<div class="alert feedback-alert center" style="display: none;">
+  <div class="alert-text feedback-alert-text"> </div>
    &nbsp;
   <a href="#" class="close-alert grow"><i class="fa fa-times-circle"></i></a>
 </div>
@@ -12,36 +12,53 @@
       <h2 class="title-no-margin"><%= @question %></h2>
       <br>
       <%= form_for @answer, :url => question_answers_path(@question_id), remote: true do |f| %>
-        <%= f.text_area :text, autofocus: true, placeholder: 'Type your answer here', class: 'form-control', id: 'single-answer-text' %>
+        <%= f.text_area :text, autofocus: true, placeholder: 'Type your answer here', class: 'form-control answer-text', id: 'single-answer-text' %>
         <div class="btn-div">
-          <%= f.submit "Submit answer", class: 'btn btn-theme btn-lg', id: 'single-submit-answer' %>
+          <%= f.submit "Submit answer", class: 'btn btn-theme btn-lg submit-answer', id: 'single-submit-answer' %>
         </div>
      <%end%>
     </div>
   </div>
 </div>
-<div class="prettyform">
+<div class="prettyform answers" style="display:none">
   <div class="container">
-    <div id="single-answers" class="box center">
+    <div class="box center">
       <h3>Answer:</h3>
-      <div class="correct_div">
+      <div class="correct-container">
         <h4 class="correct"><%= @answers[0]["text"] %></h4>
       </div>
     </div>
   </div>
 </div>
-<div id="single-response">
+<div class="response" style="display:none">
   <br>
   <h4 class="center"><b>Did you know the answer?</b></h4>
   <div class="row">
     <div class="col-xs-6 yes">
-      <a id="single-respond-yes" class="btn-flat btn-success"><i class="fa fa-check"></i></a>
+      <a class="btn-flat btn-success feedback-button"
+         data-feedback-active="<%= !!current_user %>"
+         data-feedback-string="yes"
+         data-feedback-qid="<%= @question_id %>">
+        <i class="fa fa-check"></i>
+      </a>
     </div>
     <div class="col-xs-6">
-      <a id ="single-respond-no" class="btn-flat btn-pink"><i class="fa fa-times"></i></a>
+      <a class="btn-flat btn-success feedback-button"
+         data-feedback-active="<%= !!current_user %>"
+         data-feedback-string="no"
+         data-feedback-qid="<%= @question_id %>">
+        <i class="fa fa-times"></i>
+      </a>
     </div>
   </div>
 </div>
+
+<script>
+  $(document).ready(function(e) {
+    initAnswerButton();
+    initUserFeedback();
+  });
+</script>
 
 <% if false %>
   In javascript (see answers.js): call respond method with corresponding response, launch appropriate modal


### PR DESCRIPTION
Moves document.ready() javascript code into individual views, which then call init functions in the assets/javascripts libraries, so that our page-level code doesn't run on every page, only on the pages that it is intended for. This change also consolidates js code for the question#show and question modal, so we don't have too many similar versions of the same code. This change also fixes some problems with the feedback functionality, so that feedback will no longer be submitted for unauthenticated user, and the question modal sends question ID in feedback again.
