### PR TITLE
Elliott/users vote on own questions by default

### DIFF
--- a/app/assets/javascripts/global.js
+++ b/app/assets/javascripts/global.js
@@ -3,3 +3,9 @@ $(function(){
     $('.alert').slideUp();
   });
 });
+
+// To use bootstrap tooltips you need to initialize them first, for performance
+// reasons. (cf http://getbootstrap.com/javascript/#tooltips)
+function initTooltips() {
+  $('[data-toggle="tooltip"]').tooltip();
+}

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -25,6 +25,11 @@ class QuestionsController < ApplicationController
     question = current_user.questions.new(question_params)
     question.answers.first.creator = current_user
     question.save
+
+    # users get one vote for their own questions by default
+    # (so their karma/score improves as they create questions)
+    current_user.vote_for(question)
+
     msg = "Your question has been submitted! Enter another if you would like."
     redirect_to new_question_path, notice: msg
   end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -9,7 +9,9 @@
         <!-- <h4>Harvard College</h4>
         <p><span class="glyphicon glyphicon-user" aria-hidden="true"></span>  Student</p> -->
         <br><br><br>
-        <div class="total-points col-centered">
+        <div class="total-points col-centered" data-toggle="tooltip"
+             data-placement="bottom" data-trigger="click focus hover"
+             title="User score reflects questions authored and votes received on questions">
           <h2 class="vcenter"><%= @user.karma %></h2>
         </div>
         <br><br>
@@ -81,3 +83,9 @@
     </div>
   </div>
 </div>
+
+<script>
+  $(document).ready(function(){
+    initTooltips();
+  });
+</script>

--- a/lib/tasks/temporary/votes.rake
+++ b/lib/tasks/temporary/votes.rake
@@ -1,0 +1,26 @@
+# cf https://robots.thoughtbot.com/data-migrations-in-rails
+
+# This is only meant to be run once, to update all existing questions
+# whose authors had not voted for them yet; this step is note needed
+# for questions created after the changes to questions#create which
+# automatically vote up new questions as they're created (commit
+# 1159dfe57a5dfaba8bee4d42912823a765973da0).
+
+namespace :temporary do
+  desc "Updates existing questions with a default vote from their authors."
+  task update_question_author_votes: :environment do
+    users = User.includes(:questions).all
+    puts "Updating #{Question.count} questions for #{users.count} users: "
+
+    ActiveRecord::Base.transaction do
+      users.each do |user|
+        user.questions.each do |q|
+          user.vote_exclusively_for(q)
+          print '.'
+        end
+      end
+    end
+
+    puts "\nUpdated!"
+  end
+end


### PR DESCRIPTION
cf Trello [user story](https://trello.com/c/eUMJk88D/444-in-user-s-profile-include-their-score-which-should-be-calculated-by-how-many-up-votes-they-ve-received-across-all-questions-ever).
1. When a user creates a question, it will automatically receive a vote by its author (which will in turn raise the author's score/karma by one point).
2. For any existing questions in the database there is a rake task, designed to be run just once, which will ensure they get voted up by their authors. After running it, existing users' scores should reflect the desired behavior of `questions created + other users' votes received on questions`.

This doesn't consider the implications of deleting questions on a user's score, because we can't actually delete questions yet in the app. :)
