### PR TITLE
Adding a generate_question button on qset pages

### DIFF
--- a/app/assets/stylesheets/modules/buttons.css.scss
+++ b/app/assets/stylesheets/modules/buttons.css.scss
@@ -1,5 +1,6 @@
 a.btn {
   color: white;
+  margin-bottom: 5px;
 }
 
 .btn-blue {

--- a/app/assets/stylesheets/questions.css.scss
+++ b/app/assets/stylesheets/questions.css.scss
@@ -18,6 +18,26 @@
 }
 // End of (All-mine-filter relocation at different screen sizes)
 
+.generate-question-button-filter {
+  margin-left: 12px;  // aligns with left side of question list
+}
+
+// (generate-question-button-filter relocation at different screen sizes)
+// On small screens (bootstrap xs) show generate-question-button-filter
+// just above the question list, since it wraps onto its own .row
+#generate-question-button-filter-xs {
+  display: none;
+}
+@media only screen and (max-width: 767px) {
+  #generate-question-button-filter-xs {
+    display: block;
+  }
+  #generate-question-button-filter {
+    display: none;
+  }
+}
+// End of (generate-question-button-filter relocation at different screen sizes)
+
 ul.qset-list-compressed {
   list-style: none;
   padding-left: 10px;

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -13,7 +13,9 @@ class QuestionsController < ApplicationController
     @question.answers.build
     @qsets = Qset.all
     prev_cookie_id = cookies[:new_question_qset_id].to_i
-    if @qsets.map(&:id).include?(prev_cookie_id)
+    if !params[:qset].nil?
+        @question.qset_id = params[:qset]
+    elsif @qsets.map(&:id).include?(prev_cookie_id)
       @question.qset_id = prev_cookie_id
     else
       cookies.delete :new_question_qset_id

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -14,7 +14,8 @@ class QuestionsController < ApplicationController
     @qsets = Qset.all
     prev_cookie_id = cookies[:new_question_qset_id].to_i
     if !params[:qset].nil?
-        @question.qset_id = params[:qset]
+      @question.qset_id = params[:qset]
+      cookies[:new_question_qset_id] = params[:qset]
     elsif @qsets.map(&:id).include?(prev_cookie_id)
       @question.qset_id = prev_cookie_id
     else

--- a/app/views/qsets/_generate_question.html.erb
+++ b/app/views/qsets/_generate_question.html.erb
@@ -1,0 +1,3 @@
+<span class="pull-left generate-question-button-filter">
+<%= link_to "Generate Question", new_question_path(qset: @qset.id), class: "btn btn-primary all-radio" %>
+</span>

--- a/app/views/qsets/_generate_question.html.erb
+++ b/app/views/qsets/_generate_question.html.erb
@@ -1,3 +1,3 @@
 <span class="pull-left generate-question-button-filter">
-<%= link_to "Generate Question", new_question_path(qset: @qset.id), class: "btn btn-primary all-radio" %>
+  <%= link_to "Generate Question", new_question_path(qset: @qset.id), class: "btn btn-primary" %>
 </span>

--- a/app/views/qsets/_qset_list_compressed.html.erb
+++ b/app/views/qsets/_qset_list_compressed.html.erb
@@ -21,8 +21,6 @@
       New subset
     </a>
   <% end %>
-  <br>
-  <%= link_to "Generate Question", new_question_path(qset: @qset.id), class: "btn btn-primary btn-sm" %>
 </span>
 </div>
 </div> <!-- .qset-list -->

--- a/app/views/qsets/_qset_list_compressed.html.erb
+++ b/app/views/qsets/_qset_list_compressed.html.erb
@@ -11,6 +11,8 @@
       </li>
     <% end %>
   </ul>
+   <div class="button-actions">
+    <span>
   <% if can? :create, Qset %>
     <a class="btn btn-primary btn-sm"
        id="new-qset"
@@ -19,5 +21,9 @@
       New subset
     </a>
   <% end %>
+  <br>
+  <%= link_to "Generate Question", new_question_path(qset: @qset.id), class: "btn btn-primary btn-sm" %>
+</span>
+</div>
 </div> <!-- .qset-list -->
 

--- a/app/views/qsets/_qset_list_compressed.html.erb
+++ b/app/views/qsets/_qset_list_compressed.html.erb
@@ -11,17 +11,17 @@
       </li>
     <% end %>
   </ul>
-   <div class="button-actions">
+  <div class="button-actions">
     <span>
-  <% if can? :create, Qset %>
-    <a class="btn btn-primary btn-sm"
-       id="new-qset"
-       data-toggle="modal"
-       data-target="#modal-new-qset">
-      New subset
-    </a>
-  <% end %>
-</span>
-</div>
+      <% if can? :create, Qset %>
+        <a class="btn btn-primary btn-sm"
+           id="new-qset"
+           data-toggle="modal"
+           data-target="#modal-new-qset">
+          New subset
+        </a>
+      <% end %>
+    </span>
+  </div>
 </div> <!-- .qset-list -->
 

--- a/app/views/qsets/show.html.erb
+++ b/app/views/qsets/show.html.erb
@@ -1,5 +1,8 @@
 <div class="container-fluid">
   <%= render "qset_context" %>
+  <div id="generate-question-button-filter">
+  <%= render "generate_question" %>
+  </div>
   <div id="all-mine-filter-container">
     <%= render "all_mine_other_filter" %>
   </div>
@@ -8,6 +11,9 @@
       <%= render "qset_list_compressed" %>
     </div>
     <div class="col-sm-9">
+      <div id ="generate-question-button-filter-xs">
+       <%= render "generate_question" %>
+      </div>
       <div id="all-mine-filter-container-xs">
       <%= render "all_mine_other_filter" %>
       </div>

--- a/app/views/qsets/show.html.erb
+++ b/app/views/qsets/show.html.erb
@@ -1,7 +1,7 @@
 <div class="container-fluid">
   <%= render "qset_context" %>
   <div id="generate-question-button-filter">
-  <%= render "generate_question" %>
+    <%= render "generate_question" %>
   </div>
   <div id="all-mine-filter-container">
     <%= render "all_mine_other_filter" %>
@@ -12,10 +12,10 @@
     </div>
     <div class="col-sm-9">
       <div id ="generate-question-button-filter-xs">
-       <%= render "generate_question" %>
+        <%= render "generate_question" %>
       </div>
       <div id="all-mine-filter-container-xs">
-      <%= render "all_mine_other_filter" %>
+        <%= render "all_mine_other_filter" %>
       </div>
       <%= render "question_list" %>
     </div>


### PR DESCRIPTION
This new feature creates a "generate question" button on each qset page that is not an "organization set".  If a user hits this new "generate question" button from the Qset page then they are redirected to the Generate Question page with that qset preselected for them in the dropdown. Alternatively, if the user choses to go to the Generate Question page directly then the last qset they selected will be pre-selected for them.
