### PR TITLE
qset permissions saved as strings are now converted into booleans to …

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -5,14 +5,14 @@ class Ability
     if user.nil?  # if the request is from someone who is not logged in
       cannot :index, Qset  # no root org, so wouldn't know where to take the visitor
       can :show, Qset do |qset|
-        qset.settings(:permissions).questions_visible_to_unauth_user
+        qset.settings(:permissions).questions_visible_to_unauth_user == 'true'
       end
       can :see_all_questions, Qset do |qset|
-        qset.settings(:permissions).all_questions_visible
+        qset.settings(:permissions).all_questions_visible == 'true'
       end
       can :read, Question
       can :see_question_author, Question do |q|
-        q.qset.settings(:permissions).question_authors_visible
+        q.qset.settings(:permissions).question_authors_visible == 'true'
       end
     else
       if user.role? :admin
@@ -22,14 +22,14 @@ class Ability
       elsif user.role? :contributor
         can :read, Qset
         can :see_all_questions, Qset do |qset|
-          qset.settings(:permissions).all_questions_visible
+          qset.settings(:permissions).all_questions_visible == 'true'
         end
         can [:downvote, :read, :upvote], Question do |q|
-          q.qset.settings(:permissions).all_questions_visible
+          q.qset.settings(:permissions).all_questions_visible == 'true'
         end
         can :manage, Question, :user_id => user.id
         can :see_question_author, Question do |q|
-          (q.qset.settings(:permissions).question_authors_visible or q.user == user)
+          (q.qset.settings(:permissions).question_authors_visible == 'true' or q.user == user)
         end
         can :manage, User, :id => user.id
         can :read, User


### PR DESCRIPTION
…test permissions in ability.rb

Permissions are saved as strings into the database, but we were assuming they were boolean values in ability.rb (which governs the permissions behavior). This fix explicitly checks whether the string is 'true', and otherwise treats the permission as false.
