### PR TITLE
Static profile pic showing up on profile page

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -3,7 +3,6 @@
     <div class="col-sm-3">
       <div class="box center dash-profile">
         <%= image_tag ("person.png") %>
-        <!--<img class="prof-pic-circle" src="/assets/person.png">-->
         <br><br>
         <h3><%= @user.first_name %> <%= @user.last_name %></h3>
         <h4><%= @user.email %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,7 +2,8 @@
   <div class="row">
     <div class="col-sm-3">
       <div class="box center dash-profile">
-        <img class="prof-pic-circle" src="/assets/person.png">
+        <%= asset_path('person.png') %>
+        <!--<img class="prof-pic-circle" src="/assets/person.png">-->
         <br><br>
         <h3><%= @user.first_name %> <%= @user.last_name %></h3>
         <h4><%= @user.email %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="col-sm-3">
       <div class="box center dash-profile">
-        <%= asset_path('person.png') %>
+        <%= image_tag ("person.png") %>
         <!--<img class="prof-pic-circle" src="/assets/person.png">-->
         <br><br>
         <h3><%= @user.first_name %> <%= @user.last_name %></h3>


### PR DESCRIPTION
- In reference to Trello card "Profile picture not showing on powerful-earth"
- Did troubleshooting of the[ asset pipeline via heroku](https://devcenter.heroku.com/articles/rails-asset-pipeline) but it was a Rails error because we were not using the[ asset tag helpers](http://api.rubyonrails.org/classes/ActionView/Helpers/AssetTagHelper.html)
- In deployment at: https://whispering-cove-82714.herokuapp.com/
