### PR TITLE
generate new question page: qset select dropdown 

### DIFF
--- a/app/views/questions/new.html.erb
+++ b/app/views/questions/new.html.erb
@@ -5,15 +5,23 @@
         <div class="box">
           <h2 class="title-no-margin center">New Question</h2>
           <br>
-            <%= form_for(@question) do |f| %>
-              <%= f.text_field :text, placeholder: 'Question',  class: 'form-control', autofocus: true %>
-              <%= f.label :qset_id, 'Qset' %>
-              <%= f.collection_select(:qset_id, Qset.find(current_user.org).descendants, :id, :name) %>
+            <%= form_for @question do |f| %>
+              <div class="form-group">
+                <%= f.text_field :text, placeholder: 'Question', class: 'form-control', autofocus: true %>
+              </div>
+              <div class="form-group">
+                <%= f.label :qset_id, 'Qset', {class: 'control-label'} %>
+                <%= f.collection_select(:qset_id, Qset.find(current_user.org).descendants, :id, :name, {}, {class: 'form-control'}) %>
+              </div>
               <%= f.fields_for :answers do |a| %>
-                <%= a.text_area :text, placeholder: 'Answer',  class: 'form-control' %>
+                <div class="form-group">
+                  <%= a.text_area :text, placeholder: 'Answer',  class: 'form-control' %>
+                </div>
               <% end %>
-              <div class="center btn-div">
-                <%= f.submit "Submit question", class: 'btn btn-theme btn-lg submit-question' %>
+              <div class="form-group">
+                <div class="center btn-div">
+                  <%= f.submit "Submit question", class: 'btn btn-theme btn-lg submit-question' %>
+                </div>
               </div>
             <%end%>
         </div>


### PR DESCRIPTION
Qset select dropdown is now full-width and responsive. Fixes bug reported in https://trello.com/c/MIChp32g/530-mobile-qset-dropdown-on-new-question-page-is-too-wide-for-screen.

Our previous code wasn't using [bootstrap forms](http://getbootstrap.com/css/#forms) quite right, so we weren't getting the responsive benefits of bootstrap's default behavior. This should fix it up so that the width of the dropdown is always commensurate with the width of the other fields and the containing box.

Reviewer is @lizamcpherson01.
