### PR TITLE
Added view here link when question is generated

### DIFF
--- a/app/assets/stylesheets/modules/alerts.css.scss
+++ b/app/assets/stylesheets/modules/alerts.css.scss
@@ -7,8 +7,12 @@
     cursor: pointer;
   }
   a:hover {
-    color: white;
+    color: black;
     
+  }
+  a:enabled {
+    font-weight: bold;
+    text-decoration: underline;
   }
 }
 

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -1,6 +1,9 @@
 class QuestionsController < ApplicationController
   load_and_authorize_resource
 
+  before_filter -> { flash.now[:notice] = flash[:notice].html_safe if flash[:html_safe] && flash[:notice] }
+
+
   # loads the page showing details for a single question so that a user
   #   can review the answer and specify whether he/she knew the answer
   def show
@@ -33,8 +36,8 @@ class QuestionsController < ApplicationController
     # (so their karma/score improves as they create questions)
     current_user.vote_for(question)
 
-    msg = "Your question has been submitted! View it #{view_context.link_to("here", qset_path(question_params[:qset_id]))}"
-    redirect_to new_question_path, notice: msg
+    msg = %Q[Your question has been submitted! View it #{view_context.link_to("here", qset_path(question_params[:qset_id]))}].html_safe
+    redirect_to new_question_path, notice: msg, flash: { html_safe: true }
   end
 
   # handles the request to update an existing question (called from the edit question page)

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -33,7 +33,7 @@ class QuestionsController < ApplicationController
     # (so their karma/score improves as they create questions)
     current_user.vote_for(question)
 
-    msg = "Your question has been submitted! Enter another if you would like."
+    msg = "Your question has been submitted! View it #{view_context.link_to("here", qset_path(question_params[:qset_id]))}"
     redirect_to new_question_path, notice: msg
   end
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -52,7 +52,7 @@
 
 <% if flash[:notice] %>
   <div class="alert alert-success center">
-    <%= flash[:notice] %> &nbsp;
+    <%= flash[:notice].html_safe %> &nbsp;
     <a href="#" class="close-alert grow"><i class="fa fa-times-circle"></i></a>
   </div>
   <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -52,7 +52,7 @@
 
 <% if flash[:notice] %>
   <div class="alert alert-success center">
-    <%= flash[:notice].html_safe %> &nbsp;
+    <%= flash[:notice] %> &nbsp;
     <a href="#" class="close-alert grow"><i class="fa fa-times-circle"></i></a>
   </div>
   <% end %>


### PR DESCRIPTION
- Added link within the green success alert that allows user to view the question they just generated
- Changed CSS to show the link bolded and underlined
- Made flash div in  the template html_safe so that the tag is not printed as a string

Some considerations:
There are discussions that claim html_safe should never be used for [security reasons](https://bibwild.wordpress.com/2013/12/19/you-never-want-to-call-html_safe-in-a-rails-template/)
But I tried to put the html_safe tag in the questions_controller as the notice msg is generated but for some reason that did still only printed as string.

Live deployed at https://whispering-cove-82714.herokuapp.com/questions/new
