### PR TITLE
new question qset selection fix

### DIFF
--- a/app/views/questions/_new_modal.html.erb
+++ b/app/views/questions/_new_modal.html.erb
@@ -6,33 +6,31 @@
         <h4 class="modal-title" id="modal-launch-title">Choose Qset</h4>
       </div>
       <div class="modal-body">
-        <!-- displays qsets in hierarchical order -->
+        <%# displays qsets in hierarchical order %>
+        <%# root/org not included (walk_tree used on an instance does not include that instance in the tree) %>
         <div class="list-group">
-          <% qsets.walk_tree do |qset, level| %>
-            <!-- don't display root qset  -->
-            <% if level > 0 %>
-              <% level_viz = '&nbsp;&nbsp;&nbsp;&nbsp;' * (level - 1) %>
-              <!-- display disabled subset qsets -->
-              <% if qset.settings(:permissions).qset_type == 'subsets' %>
-                <a href="#" class="list-group-item disabled">
-                  <%= level_viz.html_safe %>
-                  <span class="glyphicon glyphicon-folder-close"></span>
-                  <p class="qset-name-modal">
-                    <%= '&nbsp;&nbsp;'.html_safe %>
-                    <%= qset.name %>
-                  </p>
-                </a>
-              <!-- display selectable question/mixed qsets -->
-              <% else %>
-                <a href="#" class="list-group-item qset-selectable">
-                  <%= level_viz.html_safe %>
-                  <span class="glyphicon glyphicon-list-alt"></span>
-                  <p class="qset-name-modal" data-qset-id="<%= qset.id %>" data-qset-name="<%= qset.name %>">
-                    <%= '&nbsp;&nbsp;'.html_safe %>
-                    <%= qset.name %>
-                  </p>
-                </a>
-              <% end %>
+          <% qset.walk_tree do |qset, level| %>
+            <% level_viz = '&nbsp;&nbsp;&nbsp;&nbsp;' * level %>
+            <%# display disabled subset qsets %>
+            <% if qset.settings(:permissions).qset_type == 'subsets' %>
+              <a href="#" class="list-group-item disabled">
+                <%= level_viz.html_safe %>
+                <span class="glyphicon glyphicon-folder-close"></span>
+                <p class="qset-name-modal">
+                  <%= '&nbsp;&nbsp;'.html_safe %>
+                  <%= qset.name %>
+                </p>
+              </a>
+            <%# display selectable question/mixed qsets %>
+            <% else %>
+              <a href="#" class="list-group-item qset-selectable">
+                <%= level_viz.html_safe %>
+                <span class="glyphicon glyphicon-list-alt"></span>
+                <p class="qset-name-modal" data-qset-id="<%= qset.id %>" data-qset-name="<%= qset.name %>">
+                  <%= '&nbsp;&nbsp;'.html_safe %>
+                  <%= qset.name %>
+                </p>
+              </a>
             <% end %>
           <% end %>
         </div>

--- a/app/views/questions/new.html.erb
+++ b/app/views/questions/new.html.erb
@@ -13,18 +13,19 @@
                 <button type="button" class="btn btn-primary btn-theme btn-generate-q" data-toggle="modal" data-target="#modal-launch">
                   Choose Qset
                 </button>
-                <% if @qset_id %>
+                <% if @question.qset_id %>
                   <span class="qset-display">
                     <%= @qset_name %>
                   </span>
-                  <input type="text" name="question[qset_id]" id="qset-id-input" class="hidden" value="<%= @qset_id %>">
+                  <input type="text" name="question[qset_id]" id="qset-id-input" class="hidden" value="<%= @question.qset_id %>">
                 <% else %>
                   <span class="qset-display no-qset-chosen">No question set chosen</span>
                   <input type="text" name="question[qset_id]" id="qset-id-input" class="hidden">
                 <% end %>
               </div>
-              <!-- Modal -->
-              <%= render(:partial => "new_modal", :locals => {:qsets => @qsets}) %>
+              <!-- Start select qset modal -->
+              <%= render(:partial => "new_modal", :locals => {:qset => current_user.org }) %>
+              <!-- End select qset modal -->
               <%= f.fields_for :answers do |a| %>
                 <div class="form-group">
                   <%= a.text_area :text, placeholder: 'Answer',  class: 'form-control' %>


### PR DESCRIPTION
Fixes bugs where qsets from other orgs were being shown when creating a new question.

Easiest to test by using an admin user, opening a tab to their profile page so you can switch back and forth between orgs/root qsets, and ensure that:
(a) sending the `qset=x` param works (valid qsets are selected, and the root qset, any non-org qset, and garbage like alphabetic qset IDs do not work/fail silently)
(b) sending the cookie works (that is, after creating a qset, the cookie persists the default as the last qset you created a question for)
(c) other tests I haven't thought of...?

Code is testable at https://askup-test.herokuapp.com/ -- there are two root qsets (two 'orgs') that the auadmin user can toggle between for testing.
